### PR TITLE
chore: export `DEFAULT_IGNORES`

### DIFF
--- a/.changeset/eighty-planes-itch.md
+++ b/.changeset/eighty-planes-itch.md
@@ -1,0 +1,5 @@
+---
+"@huntabyte/eslint-config": patch
+---
+
+chore: export `DEFAULT_IGNORES`

--- a/packages/eslint-config/src/factory.ts
+++ b/packages/eslint-config/src/factory.ts
@@ -12,7 +12,7 @@ export type UserConfig = Awaitable<
 	TypedFlatConfigItem | TypedFlatConfigItem[] | FlatConfigPipeline<any>
 >;
 
-const DEFAULT_IGNORES = ['**/.svelte-kit', '**/dist', '**/build', '**/static', '**/*.md'];
+export const DEFAULT_IGNORES = ['**/.svelte-kit', '**/dist', '**/build', '**/static', '**/*.md'];
 
 const defaultOptions: Options = {
 	stylistic: false,


### PR DESCRIPTION
This will make it easier to extend without having to rewrite the defaults each time but still provide the flexibility to do so.